### PR TITLE
Check for horizontal symmetry as well

### DIFF
--- a/src/main/java/TownBuilder/Buildings/BuildingFactory.java
+++ b/src/main/java/TownBuilder/Buildings/BuildingFactory.java
@@ -119,19 +119,21 @@ public class BuildingFactory {
         // add the 3 rotations
         ResourceEnum[][] p = pattern;
         for (int i = 0; i < 3; i++) {
-            p = Utility.rotatePattern(p);
+            p = Utility.rotate90(p);
             patternList.add(p);
         }
 
-        // mirror, then repeat
-        ResourceEnum[][] mirror = Utility.mirrorPattern(pattern);
-        // if the mirror is different (i.e. the pattern isn't symmetrical) we
-        // have some more transformations to compute
-        if (!Arrays.deepEquals(mirror, pattern)) {
-            patternList.add(mirror);
-            ResourceEnum[][] m = mirror;
+        // if the pattern isn't symmetrical, we have more transformations to compute
+        ResourceEnum[][] vertMirror = Utility.vertMirror(pattern);
+        boolean isVertSymmetric = Arrays.deepEquals(pattern, vertMirror);
+        ResourceEnum[][] rotatedPattern = Utility.rotate90(pattern);
+        boolean isHorizSymmetric = Arrays.deepEquals(rotatedPattern, Utility.vertMirror(rotatedPattern));
+        boolean isSymmetric = isVertSymmetric || isHorizSymmetric;
+        if (!isSymmetric) {
+            patternList.add(vertMirror);
+            ResourceEnum[][] m = vertMirror;
             for (int i = 0; i < 3; i++) {
-                m = Utility.rotatePattern(m);
+                m = Utility.rotate90(m);
                 patternList.add(m);
             }
         }

--- a/src/main/java/TownBuilder/Tests/PatternBuilderTest.java
+++ b/src/main/java/TownBuilder/Tests/PatternBuilderTest.java
@@ -1,0 +1,33 @@
+package TownBuilder.Tests;
+
+import java.util.ArrayList;
+
+import TownBuilder.Buildings.*;
+
+public class PatternBuilderTest {
+    public static void main(String[] args) {
+        // vertically symmetric
+        // total should be 4: pattern definition (1) and its rotations (3)
+        ArrayList<ResourceEnum[][]> b1 = (new Theater()).getBuildingPatternsList();
+        System.out.println("[ All transformations of Theater ]\n");
+        Utility.printMembersof3dArrayList(b1);
+        assert b1.size() == 4;
+        System.out.println("----\n");
+
+        // horizontally symmetric
+        // total should be 4: pattern definition (1) and its rotations (3)
+        ArrayList<ResourceEnum[][]> b2 = (new Tavern(0, 0)).getBuildingPatternsList();
+        System.out.println("[ All transformations of Tavern ]\n");
+        Utility.printMembersof3dArrayList(b2);
+        assert b2.size() == 4;
+        System.out.println("----\n");
+
+        // non-symmetrical
+        // total should be 8: pattern definition (1) and its rotations (3), and mirror (1) and its rotations (3)
+        ArrayList<ResourceEnum[][]> b3 = (new Chapel(0, 0)).getBuildingPatternsList();
+        System.out.println("[ All transformations of Chapel ]\n");
+        Utility.printMembersof3dArrayList(b3);
+        assert b3.size() == 8;
+        System.out.println("----\n");
+    }
+}

--- a/src/main/java/TownBuilder/Utility.java
+++ b/src/main/java/TownBuilder/Utility.java
@@ -34,7 +34,10 @@ public class Utility {
             }
         }
     }
-    public static ResourceEnum[][] rotatePattern(ResourceEnum[][] a) {
+    /*
+        Rotate pattern 90 degrees to the right.
+    */
+    public static ResourceEnum[][] rotate90(ResourceEnum[][] a) {
         final int M = a.length;
         final int N = a[0].length;
         ResourceEnum[][] ret = new ResourceEnum[N][M];
@@ -45,17 +48,20 @@ public class Utility {
         }
         return ret;
     }
-    public static ResourceEnum[] mirrorRow(ResourceEnum[] row) {
+    public static ResourceEnum[] reverseRow(ResourceEnum[] row) {
         ResourceEnum[] mirroredRow = new ResourceEnum[row.length];
         for (int i = row.length - 1; i >= 0; i--) {
             mirroredRow[row.length - 1 - i] = row[i];
         }
         return mirroredRow;
     }
-    public static ResourceEnum[][] mirrorPattern(ResourceEnum[][] array) {
+    /*
+        Vertically mirror pattern.
+    */
+    public static ResourceEnum[][] vertMirror(ResourceEnum[][] array) {
         ResourceEnum[][] mirrored2DArray = new ResourceEnum[array.length][array[0].length];
         for (int r = 0; r < array.length; r++) {
-            mirrored2DArray[r] = mirrorRow(array[r]);
+            mirrored2DArray[r] = reverseRow(array[r]);
         }
         return mirrored2DArray;
     }


### PR DESCRIPTION
Previously, we only checked for vertical symmetry and not horizontal symmetry, which meant we unnecessarily computed mirror transformations sometimes. Now we check for both, saving a bit of processing power.